### PR TITLE
Additional Contact methods

### DIFF
--- a/src/Actions/ManagesContacts.php
+++ b/src/Actions/ManagesContacts.php
@@ -120,6 +120,18 @@ trait ManagesContacts
     }
 
     /**
+     * Deletes a contact by its ActiveCampaign ID.
+     *
+     * @param int $id
+     *
+     * @return Contact|null
+     */
+    public function deleteContactById($idl)
+    {
+        $this->delete('contacts/'.$id);
+    }
+
+    /**
      * Get all automations of a contact.
      *
      * @param \TestMonitor\ActiveCampaign\Resources\Contact $contact

--- a/src/Actions/ManagesContacts.php
+++ b/src/Actions/ManagesContacts.php
@@ -51,13 +51,8 @@ trait ManagesContacts
      */
     public function findContactById($id)
     {
-        $contacts = $this->transformCollection(
-            $this->get('contacts', ['query' => ['id' => $id]]),
-            Contact::class,
-            'contacts'
-        );
-
-        return array_shift($contacts);
+        $contact = (object) $this->get('contacts/'.$id);
+        return new Contact($contact->contact);
     }
 
     /**

--- a/src/Actions/ManagesContacts.php
+++ b/src/Actions/ManagesContacts.php
@@ -102,6 +102,24 @@ trait ManagesContacts
     }
 
     /**
+     * Updates a contact by its ActiveCampaign ID.
+     *
+     * @param      $id
+     * @param      $email
+     * @param      $firstName
+     * @param      $lastName
+     * @param null $orgid
+     *
+     * @return Contact|null
+     */
+    public function updateContactById($id, $email, $firstName, $lastName, $orgid = null)
+    {
+        $this->put('contacts/'.$id, ['json' => ['contact' => compact('email', 'firstName', 'lastName', 'orgid')]]);
+
+        return $this->findContactById($id);
+    }
+
+    /**
      * Get all automations of a contact.
      *
      * @param \TestMonitor\ActiveCampaign\Resources\Contact $contact

--- a/src/Actions/ManagesContacts.php
+++ b/src/Actions/ManagesContacts.php
@@ -43,6 +43,24 @@ trait ManagesContacts
     }
 
     /**
+     * Find contact by ID.
+     *
+     * @param int $id
+     *
+     * @return Contact|null
+     */
+    public function findContactById($id)
+    {
+        $contacts = $this->transformCollection(
+            $this->get('contacts', ['query' => ['id' => $id]]),
+            Contact::class,
+            'contacts'
+        );
+
+        return array_shift($contacts);
+    }
+
+    /**
      * Create new contact.
      *
      * @param string $email

--- a/src/Actions/ManagesContacts.php
+++ b/src/Actions/ManagesContacts.php
@@ -232,6 +232,7 @@ trait ManagesContacts
             return (int) $contact;
         } else {
             $contact = $this->findContact($contact);
+
             return $contact->id;
         }
     }

--- a/src/Actions/ManagesContacts.php
+++ b/src/Actions/ManagesContacts.php
@@ -102,33 +102,33 @@ trait ManagesContacts
     }
 
     /**
-     * Updates a contact by its ActiveCampaign ID.
+     * Updates a contact.
      *
-     * @param      $id
-     * @param      $email
-     * @param      $firstName
-     * @param      $lastName
-     * @param null $orgid
+     * @param Contact|int|string $id
+     * @param string|null        $email
+     * @param string|null        $firstName
+     * @param string|null        $lastName
+     * @param null               $orgid
      *
      * @return Contact|null
      */
-    public function updateContactById($id, $email, $firstName, $lastName, $orgid = null)
+    public function updateContact($id, $email, $firstName, $lastName, $orgid = null)
     {
+        $id = $this->getContactId($id);
+
         $this->put('contacts/'.$id, ['json' => ['contact' => compact('email', 'firstName', 'lastName', 'orgid')]]);
 
         return $this->findContactById($id);
     }
 
     /**
-     * Deletes a contact by its ActiveCampaign ID.
+     * Deletes a contact.
      *
-     * @param int $id
-     *
-     * @return Contact|null
+     * @param Contact|int|string $contact
      */
-    public function deleteContactById($idl)
+    public function deleteContact($contact)
     {
-        $this->delete('contacts/'.$id);
+        $this->delete('contacts/'.$this->getContactId($contact));
     }
 
     /**
@@ -217,5 +217,22 @@ trait ManagesContacts
         }
 
         $this->delete("contactTags/{$contactTag->id}");
+    }
+
+    /**
+     * Determines the contact ID.
+     *
+     * @param Contact|int|string $contact
+     */
+    protected function getContactId($contact)
+    {
+        if ($contact instanceof Contact) {
+            return $contact->id;
+        } elseif (is_numeric($contact)) {
+            return (int) $contact;
+        } else {
+            $contact = $this->findContact($contact);
+            return $contact->id;
+        }
     }
 }

--- a/src/Actions/ManagesTags.php
+++ b/src/Actions/ManagesTags.php
@@ -47,13 +47,8 @@ trait ManagesTags
      */
     public function findTagById($id)
     {
-        $tags = $this->transformCollection(
-            $this->get('tags', ['query' => ['id' => $id]]),
-            Tag::class,
-            'tags'
-        );
-
-        return array_shift($tags);
+        $tag = (object) $this->get('tags/'.$id);
+        return new Tag($tag->tag);
     }
 
     /**

--- a/src/Actions/ManagesTags.php
+++ b/src/Actions/ManagesTags.php
@@ -133,6 +133,7 @@ trait ManagesTags
             return (int) $tag;
         } else {
             $tag = $this->findTag($tag);
+
             return $tag->id;
         }
     }

--- a/src/Actions/ManagesTags.php
+++ b/src/Actions/ManagesTags.php
@@ -77,6 +77,8 @@ trait ManagesTags
      * Find or create a tag.
      *
      * @param string $name
+     * @param string $type
+     * @param string $description
      *
      * @return Tag
      */

--- a/src/Actions/ManagesTags.php
+++ b/src/Actions/ManagesTags.php
@@ -39,6 +39,24 @@ trait ManagesTags
     }
 
     /**
+     * Find tag by id.
+     *
+     * @param string $id
+     *
+     * @return array
+     */
+    public function findTagById($id)
+    {
+        $tags = $this->transformCollection(
+            $this->get('tags', ['query' => ['id' => $id]]),
+            Tag::class,
+            'tags'
+        );
+
+        return array_shift($tags);
+    }
+
+    /**
      * Create new tag.
      *
      * @param array $data
@@ -62,7 +80,7 @@ trait ManagesTags
      *
      * @return Tag
      */
-    public function findOrCreateTag($name)
+    public function findOrCreateTag($name, $type = 'contact', $description = null)
     {
         $tag = $this->findTag($name);
 
@@ -70,6 +88,52 @@ trait ManagesTags
             return $tag;
         }
 
-        return $this->createTag(['tag' => $name]);
+        return $this->createTag(['tag' => $name, 'tagType' => $type, 'description' => $description]);
+    }
+
+    /**
+     * Updates a tag.
+     *
+     * @param Tag|int|string $id
+     * @param string|null    $tag
+     * @param string|null    $tagType
+     * @param string|null    $description
+     *
+     * @return Tag|null
+     */
+    public function updateTag($id, $tag = null, $tagType = 'contact', $description = null)
+    {
+        $id = $this->getTagId($id);
+
+        $this->put('tags/'.$id, ['json' => ['tag' => compact('tag', 'tagType', 'description', 'orgid')]]);
+
+        return $this->findTagById($id);
+    }
+
+    /**
+     * Deletes a tag.
+     *
+     * @param Tag|int|string $tag
+     */
+    public function deleteTag($tag)
+    {
+        $this->delete('tags/'.$this->getTagId($tag));
+    }
+
+    /**
+     * Determines the tag ID.
+     *
+     * @param Tag|int|string $tag
+     */
+    protected function getTagId($tag)
+    {
+        if ($tag instanceof Tag) {
+            return $tag->id;
+        } elseif (is_numeric($tag)) {
+            return (int) $tag;
+        } else {
+            $tag = $this->findTag($tag);
+            return $tag->id;
+        }
     }
 }

--- a/src/Actions/ManagesTags.php
+++ b/src/Actions/ManagesTags.php
@@ -77,12 +77,12 @@ trait ManagesTags
      * Find or create a tag.
      *
      * @param string $name
-     * @param string $type
+     * @param string $tagType
      * @param string $description
      *
      * @return Tag
      */
-    public function findOrCreateTag($name, $type = 'contact', $description = null)
+    public function findOrCreateTag($name, $tagType = 'contact', $description = null)
     {
         $tag = $this->findTag($name);
 
@@ -90,7 +90,7 @@ trait ManagesTags
             return $tag;
         }
 
-        return $this->createTag(['tag' => $name, 'tagType' => $type, 'description' => $description]);
+        return $this->createTag(['tag' => $name, 'tagType' => $tagType, 'description' => $description]);
     }
 
     /**


### PR DESCRIPTION
This PR introduces the following methods for working with contacts beyond listing and creating.

- `findContactById` - allows for a contact to be fetched using its numerical Active Campaign ID
- `updateContactById` - allows for a contact to be updated using its numerical Active Campaign ID
- `deleteContactById` - allows for a contact to be deleted using its numerical Active Campaign ID

I opted for the `*ById` convention to differentiate from the existing `findContact` method however the update and delete methods probably don't require the `ById` suffix but I wanted to keep consistency.

I'd welcome your thoughts, gracious maintainers - although an update _can_ be done without an ID, it uses the email as a primary key, so if the change is that you're updating an email then i believe a new contact will be created - I find this behaviour odd. Additionally, a delete can only be done using the ID.